### PR TITLE
added check if path is actually a folder

### DIFF
--- a/code.py
+++ b/code.py
@@ -1,27 +1,28 @@
 from os import listdir
 import code_analysis as CA
 from sys import argv
+import os
 def scan_files_in_folder(path):
     
-    
-    folders = listdir(path)
-    for i2 in folders:
-        if('.php' in i2):        
-            
-            file = open(f"{path}/{i2}","r",encoding="utf8",errors='ignore')
-            file = file.read()
-            line_number = 0
-            print(f"{path}/{i2}")
-            CA.info.GET_parameters(file)
-            CA.info.POST_parameters(file)
-            CA.check.check_all(f"{path}/{i2}")
-            CA.search.SQLi(file)
-            CA.search.check_file_upload(file)
-            
-    for i in folders:
-        if ("." not in i):
-            scan_files_in_folder(f"{path}/{i}")
-    return folders
+    if(os.path.isdir(path)):
+       folders = listdir(path)
+       for i2 in folders:
+           if('.php' in i2):        
+               
+               file = open(f"{path}/{i2}","r",encoding="utf8",errors='ignore')
+               file = file.read()
+               line_number = 0
+               print(f"{path}/{i2}")
+               CA.info.GET_parameters(file)
+               CA.info.POST_parameters(file)
+               CA.check.check_all(f"{path}/{i2}")
+               CA.search.SQLi(file)
+               CA.search.check_file_upload(file)
+               
+       for i in folders:
+           if ("." not in i):
+               scan_files_in_folder(f"{path}/{i}")
+       return folders
     
 if(len(argv) == 2):
     if(".php" in argv[1]):

--- a/code_analysis.py
+++ b/code_analysis.py
@@ -142,7 +142,7 @@ class info():
         print(colors.color.blue(check.number_of_vuln("command injection",command_injection_number_vuln)))
         print(colors.color.blue(check.number_of_vuln("LFI",LFI_number_vuln)))
         print(colors.color.blue(check.number_of_vuln("SSRF",SSRF_number_vuln)))
-        print(colors.color.blue(check.number_of_vuln("uplaod issues",check_file_upload_number_vuln)))
+        print(colors.color.blue(check.number_of_vuln("upload issues",check_file_upload_number_vuln)))
         print(colors.color.blue(check.number_of_vuln("host_header_injection",host_header_injection_number_vuln)))
         
         print(colors.color.blue(check.number_of_vuln("insecure deserialization",ID_number_vuln)))


### PR DESCRIPTION
fixes problems with files that have no suffix on unix-like-machines, like commonly used README or LICENSE files in 3rd-party libs.